### PR TITLE
chore: add sqlite-bundled for consistency of Room driver

### DIFF
--- a/build-logic/convention/src/main/java/dev/yjyoon/template/buildlogic/convention/RoomPlugin.kt
+++ b/build-logic/convention/src/main/java/dev/yjyoon/template/buildlogic/convention/RoomPlugin.kt
@@ -21,6 +21,7 @@ class RoomPlugin : Plugin<Project> {
                     getByName("commonMain").apply {
                         dependencies {
                             implementation(libs.library("room-runtime"))
+                            implementation(libs.library("sqlite-bundled"))
                         }
                     }
                 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,6 +26,7 @@ ktor = "3.0.1"
 ktorfit = "2.2.0"
 logback = "1.3.14"
 datastore = "1.1.2"
+sqlite = "2.5.0-beta01"
 room = "2.7.0-beta01"
 
 ksp = "2.1.10-1.0.30"
@@ -46,6 +47,7 @@ android-desugar = { module = "com.android.tools:desugar_jdk_libs", version.ref =
 
 datastore-core = { group = "androidx.datastore", name = "datastore-preferences-core", version.ref = "datastore" }
 
+sqlite-bundled = { group = "androidx.sqlite", name = "sqlite-bundled", version.ref = "sqlite" }
 room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
 room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
 room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }


### PR DESCRIPTION
## Description
Add dependency of `androidx.sqlite:sqlite-bundled` for using `BundledSQLiteDriver` on `RoomPlugin.kt`
It's recommended Room driver implementation on Kotlin Multiplatform for consistency across all the platforms.


## Additional Context
- https://developer.android.com/kotlin/multiplatform/sqlite
